### PR TITLE
Disable internal subroutines in SMD

### DIFF
--- a/cmd/smd/rfevent-monitor.go
+++ b/cmd/smd/rfevent-monitor.go
@@ -28,35 +28,25 @@ import (
 
 // This is the main thread that monitors the event bus
 func (s *SmD) StartRFEventMonitor() {
-	if s.msgbusListen != "" {
-		if err := s.MsgBusConfig(s.msgbusListen); err != nil {
-			s.LogAlways("WARNING: Cannot parse message bus host: %s", err)
-		} else {
-			// Loop forever trying to connect or reconnect if an error
-			// occurs.
-			for {
-				if err := s.MsgBusReconnect(); err != nil {
-					s.LogAlways("ERROR: Cannot connect to  message bus host: %s",
-						err)
-					s.LogAlways("Retrying msg bus connection in 5 seconds")
-					time.Sleep(5 * time.Second)
-					continue
-				}
-				s.LogAlways("Connected to message bus: %s:%d:%s",
-					s.msgbusConfig.Host, s.msgbusConfig.Port, s.msgbusConfig.Topic)
-
-				// Consume events from topic on message bus.  If an
-				// error occurs, report it and reconnect.
-				err := s.rfEventMonitor()
-				s.LogAlways("ERROR: Event monitor returned '%s', reconnecting",
-					err)
-			}
+	// Loop forever trying to connect or reconnect if an error
+	// occurs.
+	for {
+		if err := s.MsgBusReconnect(); err != nil {
+			s.LogAlways("ERROR: Cannot connect to  message bus host: %s",
+				err)
+			s.LogAlways("Retrying msg bus connection in 5 seconds")
+			time.Sleep(5 * time.Second)
+			continue
 		}
-	} else {
-		s.LogAlways("No message bus host given.")
+		s.LogAlways("Connected to message bus: %s:%d:%s",
+			s.msgbusConfig.Host, s.msgbusConfig.Port, s.msgbusConfig.Topic)
+
+		// Consume events from topic on message bus.  If an
+		// error occurs, report it and reconnect.
+		err := s.rfEventMonitor()
+		s.LogAlways("ERROR: Event monitor returned '%s', reconnecting",
+			err)
 	}
-	s.LogAlways("Not listening for events on the message bus.")
-	return
 }
 
 // Dequeue a single event and hand it off for processing.

--- a/cmd/smd/smd-api.go
+++ b/cmd/smd/smd-api.go
@@ -2495,7 +2495,9 @@ func (s *SmD) doRedfishEndpointsPost(w http.ResponseWriter, r *http.Request) {
 	// Do discovery if needed on new Endpoints.  Should never need to
 	// force this because the endpoint should always be new, else we would
 	// have already failed the operation.
-	go s.discoverFromEndpoints(eps.RedfishEndpoints, 0, true, false)
+	if !s.disableDiscovery {
+		go s.discoverFromEndpoints(eps.RedfishEndpoints, 0, true, false)
+	}
 
 	// Send a URI array of the created resources, along with 201 (created).
 	uris := eps.GetResourceURIArray(s.redfishEPBaseV2)

--- a/cmd/smd/smd.go
+++ b/cmd/smd/smd.go
@@ -106,6 +106,7 @@ type SmD struct {
 	hwInvHistAgeMax int
 	smapCompEP      *SyncMap
 	genTestPayloads string
+	disableDiscovery bool
 
 	// v2 APIs
 	apiRootV2           string
@@ -550,6 +551,7 @@ func (s *SmD) parseCmdLine() {
 	flag.StringVar(&s.dbHost, "dbhost", "", "Database hostname")
 	flag.StringVar(&s.dbPortStr, "dbport", "", "Database port")
 	flag.StringVar(&s.dbOpts, "dbopts", "", "Database options string")
+	flag.BoolVar(&s.disableDiscovery, "disable-discovery", false, "Disable discovery-related subroutines")
 	help := flag.Bool("h", false, "Print help and exit")
 
 	flag.Parse()
@@ -915,8 +917,10 @@ func main() {
 	s.srfpJobList = make(map[string]*Job, 0)
 	s.discMap = make(map[string]int, 0)
 	s.JobSync()
-	s.DiscoverySync()
-	s.DiscoveryUpdater()
+	if !s.disableDiscovery {
+		s.DiscoverySync()
+		s.DiscoveryUpdater()
+	}
 
 	// Start serving HTTP
 	var router *mux.Router


### PR DESCRIPTION
## Summary and Scope

_Edit: PR should be merged into `ochami-demo` and not `master` branch._

Disable SMD internal subroutines with CLI flags. Redfish event monitoring is disabled by default by not setting `msg-host` and discovery is disabled by setting the `--disable-discovery=true` flag.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Fixes issue [#13](https://github.com/bikeshack/ochami-lanl-dev/issues/13).

## Testing

_List the environments in which these changes were tested._

Tested on:

  * Local development environment with changes and httpbin

Test description:

- Build binaries, then start SMD
- Run curl with something like: `curl -d '{"ID": "x0c0s14b3", "Hostname": "127.0.0.1:80", "RediscoverOnUpdate":true}' -H "Content-Type: application/json" -X POST http://127.0.0.1:27779/hsm/v2/Inventory/RedfishEndpoints
[{"URI":"/hsm/v2/Inventory/RedfishEndpoints/x0c0s14b3"}]`
- Check for following output:
```bash
2023/09/20 14:44:10 [DEBUG] GET https://127.0.0.1:80/redfish/v1
2023/09/20 14:44:12 [ERR] GET https://127.0.0.1:80/redfish/v1 request failed: Get "https://127.0.0.1:80/redfish/v1": EOF
2023/09/20 14:44:12.508609 rfendpoints.go:688: GETRelative (https://127.0.0.1:80/redfish/v1) ERROR: GET https://127.0.0.1:80/redfish/v1 giving up after 1 attempt(s): Get "https://127.0.0.1:80/redfish/v1": EOF, Retrying...
```
If this output is there, then the discovery is NOT disabled.


## Risks and Mitigations

No known issue, and PR should maintain default behavior is flag


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
