### PR TITLE
updated .goreleaser.yaml. Docker section fails on wildcards for some …

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,7 +63,7 @@ dockers:
       - LICENSE
       - CHANGELOG.md
       - README.md
-      - migrations/*
+      - migrations/
 
 
 


### PR DESCRIPTION
goreleaser is complaining about wildcards in the docker-build section  
removing it seems to work in a snapshot build